### PR TITLE
refactor: move error handling from service to component

### DIFF
--- a/src/config/axios/setup.ts
+++ b/src/config/axios/setup.ts
@@ -7,6 +7,7 @@ const api = axios.create({
   headers: {
     'Content-Type': 'application/json',
   },
+  validateStatus: () => true,
 });
 
 applyInterceptors(api);

--- a/src/section/Todo/api/todoService.ts
+++ b/src/section/Todo/api/todoService.ts
@@ -11,52 +11,32 @@ export const getAllTodo = async (
   sortType: string,
   sortColumn: string
 ) => {
-  try {
-    const res = await api.get<PaginatedTodosResponse>(
-      `api/todos?page=${page}&limit=${totalPerPage}&sortType=${sortType}&sortColumn=${sortColumn}`
-    );
+  const res = await api.get<PaginatedTodosResponse>(
+    `api/todos?page=${page}&limit=${totalPerPage}&sortType=${sortType}&sortColumn=${sortColumn}`
+  );
 
-    return res.data;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  } catch (error: any) {
-    throw new Error(error.response?.data?.message || error.message || 'Unknown Axios error');
-  }
+  return res.data;
 };
 
 export const getTotalTodosAndTotalFinishTodos = async () => {
-  try {
-    const res = await api.get<getTotalTodosAndTotalFinishTodosResponse>(`api/todos/total`);
+  const res = await api.get<getTotalTodosAndTotalFinishTodosResponse>(`api/todos/total`);
 
-    return res.data;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  } catch (error: any) {
-    throw new Error(error.response?.data?.message || error.message || 'Unknown Axios error');
-  }
+  return res.data;
 };
 
 export const getTodoById = async (id: string) => {
-  try {
-    const res = await api.get<TodoValue>(`api/todos/${id}`);
+  const res = await api.get<TodoValue>(`api/todos/${id}`);
 
-    return res.data;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  } catch (error: any) {
-    throw new Error(error.response?.data?.message || error.message || 'Unknown Axios error');
-  }
+  return res.data;
 };
 
 export const createTodo = async (newTodo: TodoValue) => {
-  try {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { id, ...newObj } = newTodo;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { id, ...newObj } = newTodo;
 
-    const res = await api.post<TodoValue>('/api/todos', newObj);
+  const res = await api.post<TodoValue>('/api/todos', newObj);
 
-    return res.data;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  } catch (error: any) {
-    throw new Error(error.response?.data?.message || error.message || 'Unknown Axios error');
-  }
+  return res.data;
 };
 
 export const updateStatusTodo = async ({
@@ -66,36 +46,21 @@ export const updateStatusTodo = async ({
   id: string;
   status: 'todo' | 'in-progress' | 'done';
 }) => {
-  try {
-    const res = await api.patch<TodoValue>(`/api/todos/${id}/status`, { status });
+  const res = await api.patch<TodoValue>(`/api/todos/${id}/status`, { status });
 
-    return res.data;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  } catch (error: any) {
-    throw new Error(error.response?.data?.message || error.message || 'Unknown Axios error');
-  }
+  return res.data;
 };
 
 export const updateTodo = async ({ todo }: { todo: TodoValue }) => {
-  try {
-    const { id, ...newObj } = todo;
+  const { id, ...newObj } = todo;
 
-    const res = await api.put<TodoValue>(`/api/todos/${id}`, { ...newObj });
+  const res = await api.put<TodoValue>(`/api/todos/${id}`, { ...newObj });
 
-    return res.data;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  } catch (error: any) {
-    throw new Error(error.response?.data?.message || error.message || 'Unknown Axios error');
-  }
+  return res.data;
 };
 
 export const deleteTodo = async ({ id }: { id: string }) => {
-  try {
-    const res = await api.delete<TodoValue>(`/api/todos/${id}`);
+  const res = await api.delete<TodoValue>(`/api/todos/${id}`);
 
-    return res.data;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  } catch (error: any) {
-    throw new Error(error.response?.data?.message || error.message || 'Unknown Axios error');
-  }
+  return res.data;
 };

--- a/src/section/Todo/api/todoService.ts
+++ b/src/section/Todo/api/todoService.ts
@@ -4,13 +4,14 @@ import {
   PaginatedTodosResponse,
   TodoValue,
 } from '../types/ITodoList';
+import { ApiResponse } from '../types/common';
 
 export const getAllTodo = async (
   page: number,
   totalPerPage: number,
   sortType: string,
   sortColumn: string
-) => {
+): Promise<PaginatedTodosResponse> => {
   const res = await api.get<PaginatedTodosResponse>(
     `api/todos?page=${page}&limit=${totalPerPage}&sortType=${sortType}&sortColumn=${sortColumn}`
   );
@@ -18,23 +19,24 @@ export const getAllTodo = async (
   return res.data;
 };
 
-export const getTotalTodosAndTotalFinishTodos = async () => {
-  const res = await api.get<getTotalTodosAndTotalFinishTodosResponse>(`api/todos/total`);
+export const getTotalTodosAndTotalFinishTodos =
+  async (): Promise<getTotalTodosAndTotalFinishTodosResponse> => {
+    const res = await api.get<getTotalTodosAndTotalFinishTodosResponse>(`api/todos/total`);
+
+    return res.data;
+  };
+
+export const getTodoById = async (id: string): Promise<ApiResponse<TodoValue>> => {
+  const res = await api.get<ApiResponse<TodoValue>>(`api/todos/${id}`);
 
   return res.data;
 };
 
-export const getTodoById = async (id: string) => {
-  const res = await api.get<TodoValue>(`api/todos/${id}`);
-
-  return res.data;
-};
-
-export const createTodo = async (newTodo: TodoValue) => {
+export const createTodo = async (newTodo: TodoValue): Promise<ApiResponse<TodoValue>> => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { id, ...newObj } = newTodo;
 
-  const res = await api.post<TodoValue>('/api/todos', newObj);
+  const res = await api.post<ApiResponse<TodoValue>>('/api/todos', newObj);
 
   return res.data;
 };
@@ -45,22 +47,26 @@ export const updateStatusTodo = async ({
 }: {
   id: string;
   status: 'todo' | 'in-progress' | 'done';
-}) => {
-  const res = await api.patch<TodoValue>(`/api/todos/${id}/status`, { status });
+}): Promise<ApiResponse<TodoValue>> => {
+  const res = await api.patch<ApiResponse<TodoValue>>(`/api/todos/${id}/status`, { status });
 
   return res.data;
 };
 
-export const updateTodo = async ({ todo }: { todo: TodoValue }) => {
+export const updateTodo = async ({
+  todo,
+}: {
+  todo: TodoValue;
+}): Promise<ApiResponse<TodoValue>> => {
   const { id, ...newObj } = todo;
 
-  const res = await api.put<TodoValue>(`/api/todos/${id}`, { ...newObj });
+  const res = await api.put<ApiResponse<TodoValue>>(`/api/todos/${id}`, { ...newObj });
 
   return res.data;
 };
 
-export const deleteTodo = async ({ id }: { id: string }) => {
-  const res = await api.delete<TodoValue>(`/api/todos/${id}`);
+export const deleteTodo = async ({ id }: { id: string }): Promise<ApiResponse<TodoValue>> => {
+  const res = await api.delete<ApiResponse<TodoValue>>(`/api/todos/${id}`);
 
   return res.data;
 };

--- a/src/section/Todo/components/Pagination/index.tsx
+++ b/src/section/Todo/components/Pagination/index.tsx
@@ -29,7 +29,7 @@ const TodosPagination = ({
   onPageChange,
   isLoading,
 }: PaginationProps) => {
-  const TotalTodos = useTodosStore(state => state.todos.pagination.total);
+  const TotalTodos = useTodosStore(state => state.todos.pagination?.total ?? 0);
 
   const totalPages = useMemo(
     () => Math.ceil(TotalTodos / itemsPerPage),

--- a/src/section/Todo/components/PrioritySelect/index.tsx
+++ b/src/section/Todo/components/PrioritySelect/index.tsx
@@ -11,13 +11,16 @@ import {
 } from '@/components/ui/select';
 import React from 'react';
 import { getTriggerBg } from '../../utils/getTriggerBg';
+import { WarningOutlined } from '@ant-design/icons';
 
 export default function PrioritySelect({
   value,
   onChange,
+  error,
 }: {
   value?: string;
   onChange?: (value: string) => void;
+  error: string;
 }) {
   return (
     <Select
@@ -60,6 +63,12 @@ export default function PrioritySelect({
           </SelectItem>
         </SelectGroup>
       </SelectContent>
+      {error && (
+        <p className="flex items-center text-xs font-medium text-red-500">
+          <WarningOutlined className="pr-1" />
+          {error}
+        </p>
+      )}
     </Select>
   );
 }

--- a/src/section/Todo/components/TodoForm/index.tsx
+++ b/src/section/Todo/components/TodoForm/index.tsx
@@ -14,6 +14,7 @@ import { useUpdateTodo } from '../../hooks/useUpdateTodo';
 import { useAddTodo } from '../../hooks/useAddTodo';
 import { ToastType } from '@/components/Toast/types/IToast';
 import { useToast } from '@/components/Toast/hooks/useToast';
+import { error } from '../../types/common';
 
 function TodoForm({ todoToUpdate }: TodoFormProps) {
   const router = useRouter();
@@ -27,24 +28,38 @@ function TodoForm({ todoToUpdate }: TodoFormProps) {
   const handleUpdateTodo = async (data: { todo: TodoValue }) => {
     try {
       await updateMutation.mutateAsync(data);
+
       showToast('Todo updated successfully!', ToastType.SUCCESS);
+
       router.push('/todo-list');
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (error: any) {
-      showToast('Failed to update todo. Please try again.' + error, ToastType.ERROR);
+      if (error && typeof error === 'object') {
+        const err = error as error;
+
+        const message = err.response?.data?.message || err.message || 'Unknown Axios error';
+
+        showToast('Failed to update todo. Please try again. ' + message, ToastType.ERROR);
+      }
     }
   };
 
   const handleAddTodo = async (todo: TodoValue) => {
     try {
       await addMutation.mutateAsync(todo);
-      showToast('Todo added successfully!', ToastType.SUCCESS);
-      router.push('/todo-list');
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (error: any) {
-      showToast('Failed to added todo. Please try again.' + error, ToastType.ERROR);
+      showToast('Todo added successfully!', ToastType.SUCCESS);
+
+      router.push('/todo-list');
+    } catch (error: unknown) {
+      if (error && typeof error === 'object') {
+        const err = error as error;
+
+        const message = err.response?.data?.message || err.message || 'Unknown Axios error';
+
+        showToast('Failed to added todo. Please try again. ' + message, ToastType.ERROR);
+      }
     }
   };
 

--- a/src/section/Todo/components/TodoForm/index.tsx
+++ b/src/section/Todo/components/TodoForm/index.tsx
@@ -14,7 +14,6 @@ import { useUpdateTodo } from '../../hooks/useUpdateTodo';
 import { useAddTodo } from '../../hooks/useAddTodo';
 import { ToastType } from '@/components/Toast/types/IToast';
 import { useToast } from '@/components/Toast/hooks/useToast';
-import { error } from '../../types/common';
 
 function TodoForm({ todoToUpdate }: TodoFormProps) {
   const router = useRouter();
@@ -27,39 +26,33 @@ function TodoForm({ todoToUpdate }: TodoFormProps) {
 
   const handleUpdateTodo = async (data: { todo: TodoValue }) => {
     try {
-      await updateMutation.mutateAsync(data);
+      const res = await updateMutation.mutateAsync(data);
 
-      showToast('Todo updated successfully!', ToastType.SUCCESS);
+      if (res.error) {
+        showToast(res.message.join(', '), ToastType.ERROR);
+      } else {
+        showToast('Todo updated successfully', ToastType.SUCCESS);
 
-      router.push('/todo-list');
-
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (error: any) {
-      if (error && typeof error === 'object') {
-        const err = error as error;
-
-        const message = err.response?.data?.message || err.message || 'Unknown Axios error';
-
-        showToast('Failed to update todo. Please try again. ' + message, ToastType.ERROR);
+        router.push('/todo-list');
       }
+    } catch (error) {
+      showToast('Network/server error occurred. ' + error, ToastType.ERROR);
     }
   };
 
   const handleAddTodo = async (todo: TodoValue) => {
     try {
-      await addMutation.mutateAsync(todo);
+      const res = await addMutation.mutateAsync(todo);
 
-      showToast('Todo added successfully!', ToastType.SUCCESS);
+      if (res.error) {
+        showToast(res.message.join(', '), ToastType.ERROR);
+      } else {
+        showToast('Todo created successfully', ToastType.SUCCESS);
 
-      router.push('/todo-list');
-    } catch (error: unknown) {
-      if (error && typeof error === 'object') {
-        const err = error as error;
-
-        const message = err.response?.data?.message || err.message || 'Unknown Axios error';
-
-        showToast('Failed to added todo. Please try again. ' + message, ToastType.ERROR);
+        router.push('/todo-list');
       }
+    } catch (error) {
+      showToast('Network/server error occurred. ' + error, ToastType.ERROR);
     }
   };
 
@@ -97,7 +90,7 @@ function TodoForm({ todoToUpdate }: TodoFormProps) {
   };
 
   const schema = yup.object({
-    title: yup.string().required('Title is required'),
+    // title: yup.string().required('Title is required'),
 
     description: yup.string().nullable(),
 

--- a/src/section/Todo/components/TodosTable/index.tsx
+++ b/src/section/Todo/components/TodosTable/index.tsx
@@ -111,13 +111,13 @@ function TodosTable({
 
   const todos = useTodosStore(state => state.todos.data);
 
-  const TotalTodos = useTodosStore(state => state.todos.pagination.total);
+  const TotalTodos = useTodosStore(state => state.todos.pagination?.total ?? 0);
 
   // const data = useMemo(() => todos, [todos]);
 
   const table = useReactTable({
     columns,
-    data: todos,
+    data: todos ?? [],
     pageCount: Math.ceil(TotalTodos / pagination.pageSize),
     state: { sorting, pagination },
     onPaginationChange: updater => {

--- a/src/section/Todo/components/UpdateTodoModal/index.tsx
+++ b/src/section/Todo/components/UpdateTodoModal/index.tsx
@@ -14,7 +14,7 @@ export default function UpdateTodoModal({ id }: { id: string }) {
 
   useEffect(() => {
     if (data) {
-      setTodoToUpdate(data);
+      setTodoToUpdate(data.data);
     }
   }, [data, setTodoToUpdate]);
 

--- a/src/section/Todo/components/UpdateTodoStatus/index.tsx
+++ b/src/section/Todo/components/UpdateTodoStatus/index.tsx
@@ -14,31 +14,25 @@ import {
 } from '@/components/ui/select';
 import { useToast } from '@/components/Toast/hooks/useToast';
 import { ToastType } from '@/components/Toast/types/IToast';
-import { useRouter } from 'next/navigation';
-import { error } from '../../types/common';
 
 function SelectTodoStatus({ original }: { original: TodoValue }) {
   const updateStatusMutation = useUpdateTodoStatus();
 
   const currentStatus = original.status;
 
-  const router = useRouter();
-
   const { showToast } = useToast();
 
   const handleUpdateStatusTodo = async (id: string, status: 'todo' | 'in-progress' | 'done') => {
     try {
-      await updateStatusMutation.mutateAsync({ id, status });
-      showToast('Todo status updated successfully!', ToastType.SUCCESS);
-      router.push('/todo-list');
-    } catch (error: unknown) {
-      if (error && typeof error === 'object') {
-        const err = error as error;
+      const res = await updateStatusMutation.mutateAsync({ id, status });
 
-        const message = err.response?.data?.message || err.message || 'Unknown Axios error';
-
-        showToast('Failed to update status todo. Please try again. ' + message, ToastType.ERROR);
+      if (res.error) {
+        showToast(res.message.join(', '), ToastType.ERROR);
+      } else {
+        showToast('Todo status updated successfully', ToastType.SUCCESS);
       }
+    } catch (error) {
+      showToast('Network/server error occurred. ' + error, ToastType.ERROR);
     }
   };
 

--- a/src/section/Todo/components/UpdateTodoStatus/index.tsx
+++ b/src/section/Todo/components/UpdateTodoStatus/index.tsx
@@ -15,6 +15,7 @@ import {
 import { useToast } from '@/components/Toast/hooks/useToast';
 import { ToastType } from '@/components/Toast/types/IToast';
 import { useRouter } from 'next/navigation';
+import { error } from '../../types/common';
 
 function SelectTodoStatus({ original }: { original: TodoValue }) {
   const updateStatusMutation = useUpdateTodoStatus();
@@ -30,10 +31,14 @@ function SelectTodoStatus({ original }: { original: TodoValue }) {
       await updateStatusMutation.mutateAsync({ id, status });
       showToast('Todo status updated successfully!', ToastType.SUCCESS);
       router.push('/todo-list');
+    } catch (error: unknown) {
+      if (error && typeof error === 'object') {
+        const err = error as error;
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (error: any) {
-      showToast('Failed to update status todo. Please try again.' + error, ToastType.ERROR);
+        const message = err.response?.data?.message || err.message || 'Unknown Axios error';
+
+        showToast('Failed to update status todo. Please try again. ' + message, ToastType.ERROR);
+      }
     }
   };
 

--- a/src/section/Todo/hooks/useUpdateTodo.ts
+++ b/src/section/Todo/hooks/useUpdateTodo.ts
@@ -14,7 +14,7 @@ export const useUpdateTodo = () => {
       queryClient.setQueryData<PaginatedTodosResponse>(key, oldData => {
         if (!oldData) return oldData;
 
-        const updatedTodos = oldData.data.map(item =>
+        const updatedTodos = (oldData.data ?? []).map(item =>
           item.id === todo.id ? { ...item, ...todo } : item
         );
 

--- a/src/section/Todo/hooks/useUpdateTodoStatus.ts
+++ b/src/section/Todo/hooks/useUpdateTodoStatus.ts
@@ -15,12 +15,36 @@ export const useUpdateTodoStatus = () => {
       queryClient.setQueryData<PaginatedTodosResponse>(key, oldData => {
         if (!oldData) return oldData;
 
-        const updatedTodos = oldData.data.map(item =>
-          item.id === id ? { ...item, status } : item
-        );
+        let flag = -1;
+
+        const updatedTodos = (oldData.data ?? []).map(item => {
+          if (item.id === id && item.status !== 'done' && status === 'done') {
+            flag = 1;
+          }
+
+          if (item.id === id && item.status !== 'done' && status !== 'done') {
+            flag = 0;
+          }
+
+          return item.id === id ? { ...item, status } : item;
+        });
+
+        const pagination = oldData.pagination ?? {
+          page: 1,
+          limit: 10,
+          total: 0,
+          totalPages: 1,
+          sortType: 0,
+          sortColumn: '',
+          totalFinish: 0,
+        };
 
         return {
           ...oldData,
+          pagination: {
+            ...pagination,
+            totalFinish: pagination.totalFinish + flag,
+          },
           data: updatedTodos,
         };
       });

--- a/src/section/Todo/index.tsx
+++ b/src/section/Todo/index.tsx
@@ -9,7 +9,6 @@ import Link from 'next/link';
 import { PlusOutlined } from '@ant-design/icons';
 import { ToastType } from '@/components/Toast/types/IToast';
 import { useToast } from '@/components/Toast/hooks/useToast';
-import { error } from './types/common';
 
 export default function Todo() {
   const [todoToDelete, setTodoToDelete] = useState<TodoToDeleteValues | null>(null);
@@ -31,19 +30,16 @@ export default function Todo() {
   const confirmDelete = useCallback(async () => {
     if (todoToDelete) {
       try {
-        await deleteMutation.mutateAsync({ id: todoToDelete.id });
+        const res = await deleteMutation.mutateAsync({ id: todoToDelete.id });
 
-        showToast('Todo deleted successfully!', ToastType.SUCCESS);
-      } catch (error: unknown) {
-        if (error && typeof error === 'object') {
-          const err = error as error;
-
-          const message = err.response?.data?.message || err.message || 'Unknown Axios error';
-
-          showToast('Failed to delete todo. Please try again. ' + message, ToastType.ERROR);
+        if (res.error) {
+          showToast(res.message.join(', '), ToastType.ERROR);
+        } else {
+          showToast('Todo deleted successfully', ToastType.SUCCESS);
         }
+      } catch (error) {
+        showToast('Network/server error occurred. ' + error, ToastType.ERROR);
       }
-
       setConfirmVisible(false);
 
       setTodoToDelete(null);

--- a/src/section/Todo/index.tsx
+++ b/src/section/Todo/index.tsx
@@ -9,6 +9,7 @@ import Link from 'next/link';
 import { PlusOutlined } from '@ant-design/icons';
 import { ToastType } from '@/components/Toast/types/IToast';
 import { useToast } from '@/components/Toast/hooks/useToast';
+import { error } from './types/common';
 
 export default function Todo() {
   const [todoToDelete, setTodoToDelete] = useState<TodoToDeleteValues | null>(null);
@@ -31,10 +32,16 @@ export default function Todo() {
     if (todoToDelete) {
       try {
         await deleteMutation.mutateAsync({ id: todoToDelete.id });
+
         showToast('Todo deleted successfully!', ToastType.SUCCESS);
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } catch (error: any) {
-        showToast('Failed to delete todo. Please try again.' + error, ToastType.ERROR);
+      } catch (error: unknown) {
+        if (error && typeof error === 'object') {
+          const err = error as error;
+
+          const message = err.response?.data?.message || err.message || 'Unknown Axios error';
+
+          showToast('Failed to delete todo. Please try again. ' + message, ToastType.ERROR);
+        }
       }
 
       setConfirmVisible(false);

--- a/src/section/Todo/types/ITodoList.ts
+++ b/src/section/Todo/types/ITodoList.ts
@@ -18,7 +18,7 @@ export type TodoFormValues = Omit<TodoValue, 'id' | 'dueDate' | 'status'> & {
 export type TodoToDeleteValues = Omit<TodoValue, 'status' | 'dueDate' | 'priority' | 'description'>;
 
 export interface PaginatedTodosResponse {
-  data: TodoValue[];
+  data: TodoValue[] | null;
   pagination: {
     page: number;
     limit: number;
@@ -27,12 +27,16 @@ export interface PaginatedTodosResponse {
     totalPages: number;
     sortType: number | undefined;
     sortColumn: string;
-  };
+  } | null;
+  message: string[];
+  error: boolean;
 }
 
 export interface getTotalTodosAndTotalFinishTodosResponse {
-  totalTodos: number;
-  totalFinishTodos: number;
+  totalTodos: number | null;
+  totalFinishTodos: number | null;
+  message: string[];
+  error: boolean;
 }
 
 export interface TodoFormProps {

--- a/src/section/Todo/types/common.ts
+++ b/src/section/Todo/types/common.ts
@@ -4,3 +4,10 @@ export type Pagination = {
 };
 
 export type error = { response?: { data?: { message?: string } }; message?: string };
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type ApiResponse<T = any> = {
+  data: T | null;
+  message: string[];
+  error: boolean;
+};

--- a/src/section/Todo/types/common.ts
+++ b/src/section/Todo/types/common.ts
@@ -2,3 +2,5 @@ export type Pagination = {
   pageIndex: number;
   pageSize: number;
 };
+
+export type error = { response?: { data?: { message?: string } }; message?: string };

--- a/src/section/Todo/utils/getQuerykey.ts
+++ b/src/section/Todo/utils/getQuerykey.ts
@@ -2,10 +2,10 @@ import { useTodosStore } from '@/store/todosStore';
 import { Pagination } from '../types/common';
 
 export const getQueryKey = () => {
-  const pageIndex = useTodosStore.getState().todos.pagination.page;
-  const pageSize = useTodosStore.getState().todos.pagination.limit;
-  const sortType = useTodosStore.getState().todos.pagination.sortType;
-  const sortColumn = useTodosStore.getState().todos.pagination.sortColumn;
+  const pageIndex = useTodosStore.getState().todos?.pagination?.page ?? 1;
+  const pageSize = useTodosStore.getState().todos?.pagination?.limit ?? 10;
+  const sortType = useTodosStore.getState().todos?.pagination?.sortType;
+  const sortColumn = useTodosStore.getState().todos?.pagination?.sortColumn;
 
   const paginationKey: Pagination = {
     pageIndex,

--- a/src/store/todosStore.ts
+++ b/src/store/todosStore.ts
@@ -25,6 +25,8 @@ const todosStore = create<TodoValues & TodosStoreActions>()(
           sortType: undefined,
           sortColumn: '',
         },
+        message: [],
+        error: false,
       },
       setTodos: (todos: PaginatedTodosResponse) => set(() => ({ todos })),
       clearTodos: () =>
@@ -40,6 +42,8 @@ const todosStore = create<TodoValues & TodosStoreActions>()(
               sortType: undefined,
               sortColumn: '',
             },
+            message: [],
+            error: false,
           },
         })),
     }),


### PR DESCRIPTION
- Removed try-catch from createTodo service function
- Centralized error handling in the component using a single try-catch